### PR TITLE
XIP-32 submission

### DIFF
--- a/XIP-32 submission
+++ b/XIP-32 submission
@@ -1,8 +1,21 @@
+---
+title: Xip 32
+id: 32
+type: 'XIP'
+network: 'not specified'
+status: Draft
+---
+# Proposal Summary
+
 The following tweet from Infinex official X account suggests to
 
 https://x.com/infinex_app/status/1796693183642149094
  
 Vote for who should receive a share of 30M GP from the 'GP Retirement Fund
+
+This proposal lines out how on to better create a vote which involves only commited community members with "skin in the game"
+
+# Specification
 
 Now, how about to make such a vote just available to:
 
@@ -16,3 +29,23 @@ To identify holders, Discord bots have to be added:
 
 -Guild or Collabland for EVM
 -Matrica Verification for Solana
+
+## Overview
+
+This XIP tries to address distribution of GP to exclusively very aligned community members.
+
+## Rationale
+
+Votes on Twitter can easily be botted or just soliciting non community members to vote favourable and should not be indicative.
+
+## Technical Specification
+
+not applicable. 
+
+## Test Cases
+
+not applicaple.
+
+# Copyright
+
+not applicaple.


### PR DESCRIPTION
The following tweet from Infinex official X account suggests to

https://x.com/infinex_app/status/1796693183642149094
 
Vote for who should receive a share of 30M GP from the 'GP Retirement Fund

Now, how about to make such a vote just available to:

a) NFT holders of mentioned communities

b) Infinex community members

I'd suggest to enable the vote within Infinex Discord, which would tick both of the above criteria and also incentivise 1 vote per 1 person, instead of 1 vote per wallet holding the NFTs (holders could distribute to multiple wallets)

To identify holders, Discord bots have to be added:

-Guild or Collabland for EVM
-Matrica Verification for Solana