### PR TITLE
Some XIPs had an incorrect updated data set

### DIFF
--- a/content/xips/xip-13.mdoc
+++ b/content/xips/xip-13.mdoc
@@ -6,7 +6,7 @@ type: core-upgrade
 network: Base
 status: Implemented
 created: '2024-01-29'
-updated: '2023-05-14'
+updated: '2024-05-14'
 ---
 # Proposal Summary
 

--- a/content/xips/xip-2.mdoc
+++ b/content/xips/xip-2.mdoc
@@ -7,7 +7,7 @@ network: Ethereum & Optimism
 status: Superseded
 supersededby: XIP-23
 created: '2023-11-05'
-updated: '2023-05-14'
+updated: '2024-05-14'
 ---
 # Simple Summary
 

--- a/content/xips/xip-22.mdoc
+++ b/content/xips/xip-22.mdoc
@@ -6,7 +6,7 @@ type: core-upgrade
 network: Ethereum, Base, Optimism, Arbitrum, Polygon POS, Solana
 status: Implemented
 created: '2024-05-09'
-updated: '2023-05-14'
+updated: '2024-05-14'
 ---
 # Proposal Summary
 

--- a/content/xips/xip-23.mdoc
+++ b/content/xips/xip-23.mdoc
@@ -6,7 +6,7 @@ type: core-upgrade
 network: All
 status: Implemented
 created: '2024-05-09'
-updated: '2023-05-14'
+updated: '2024-05-14'
 ---
 # Proposal Summary
 

--- a/content/xips/xip-25.mdoc
+++ b/content/xips/xip-25.mdoc
@@ -6,7 +6,7 @@ type: integration-upgrade
 network: Ethereum, Base
 status: Rejected
 created: '2024-05-11'
-updated: '2023-05-14'
+updated: '2024-05-14'
 ---
 # Proposal Summary
 XIP-25 proposes an entirely new meta on GP distribution.


### PR DESCRIPTION
Looks like a bunch of XIPs had an incorrect (off by 1 year) date set for the `updated` field when their statuses we're bumped back in PR #150.

Not sure whether the best/most correct fix is to set them to what was intended (the date when the status changes were made) or _todays_ date (as the file is effectively being updated _now_).