### PR TITLE
Fixing broken links

### DIFF
--- a/content/irs/ir-3.mdoc
+++ b/content/irs/ir-3.mdoc
@@ -47,7 +47,7 @@ Furthermore, the Operations Seat will continue to manage the existing Core Contr
 
 ### Introducing the Patron NFT as the voting mechanism for the Treasury Seat
 
-The Investor NFT was introduced in [Governance v1.0 ](https://vote.infinex.io/#/proposal/0x98619961d046180aedf60cdf7ab237eb0ef1e22ccaf728c05d346d9847c581b0)as the voting mechanism for the Treasury Seat. However, due to the lack of investors in the protocol, a new mechanism was implemented, referred to as the [Patron NFT](https://proposals.infinex.io/xips/xip-12).
+The Investor NFT was introduced in [Governance v1.0](https://vote.infinex.io/#/proposal/0x98619961d046180aedf60cdf7ab237eb0ef1e22ccaf728c05d346d9847c581b0) as the voting mechanism for the Treasury Seat. However, due to the lack of investors in the protocol, a new mechanism was implemented, referred to as the [Patron NFT](https://proposals.infinex.xyz/xips/xip-12).
 
 As such, this IR proposes that Patron NFTs become the voting mechanism for the Treasury Seat. Each Patron NFT will count as one vote and 100,000 votes can be cast (max supply of the Patron NFT). The voting process specified in Governance 1.0 remains the same.
 

--- a/content/irs/ir-4.mdoc
+++ b/content/irs/ir-4.mdoc
@@ -40,7 +40,7 @@ The Security Seat will operate in a similar manner to the Operations Seat, and w
 
 The Security Seat will manage the security and infrastructure of the protocol (including the Core WG). This includes tasks such as:
 
-1. Being the delegate of [Infinex's Infrastructure and Services (XIP-14)](https://proposals.infinex.io/xips/xip-14).
+1. Being the delegate of [Infinex's Infrastructure and Services (XIP-14)](https://proposals.infinex.xyz/xips/xip-14).
 1. Taking the initiative on improving Infinex's security.
 1. Writing security policies and procedures.
 1. Recruit and manage auditors as necessary.
@@ -57,7 +57,7 @@ Whilst the fine details of the bond are private, the minimum imposed bond will b
 
 ### Modification to Election Process of the Operations Seat
 
-In [IR-3](https://proposals.infinex.io/irs/ir-3), the Operations Seat was established with a two week nomination process. This proposal aims to shorten the nomination process to one week, and grant the Infinex Council the power to close nominations at their own discretion.
+In [IR-3](https://proposals.infinex.xyz/irs/ir-3), the Operations Seat was established with a two week nomination process. This proposal aims to shorten the nomination process to one week, and grant the Infinex Council the power to close nominations at their own discretion.
 
 # Copyright
 

--- a/content/irs/ir-5.mdoc
+++ b/content/irs/ir-5.mdoc
@@ -21,7 +21,7 @@ The following upgrades are proposed in IR-5:
 1. The rollover of the Treasury Seat.
 1. A delayed start to Epoch 2.
 
-The deployment of Governance 2.0 will also include the approved but not implemented changes from [IR-3](https://proposals.infinex.io/irs/ir-3) and [IR-4](https://proposals.infinex.io/irs/ir-4), which include
+The deployment of Governance 2.0 will also include the approved but not implemented changes from [IR-3](https://proposals.infinex.xyz/irs/ir-3) and [IR-4](https://proposals.infinex.xyz/irs/ir-4), which include
 
 - The introduction of an Operations Seat and the deprecation of the Core Contributor Seat.
 - The establishment of the Patron NFT as the voting method for the Treasury Seat.
@@ -118,7 +118,7 @@ IR-5 proposes to add an additional Trader Seat to the Infinex Council, bringing 
 
 ### A Rollover of the Treasury Seat
 
-IR-5 proposes the existing treasury seat from epoch one, which was [voted ](https://vote.infinex.io/#/proposal/0x295449db819f1b9412f94891f117818866c5a05d412f5a2369524d2fd9507ebf)in following the approval of [IR-2](https://proposals.infinex.io/irs/ir-2-governance-v1.1), be rolled over for the next epoch.
+IR-5 proposes the existing treasury seat from epoch one, which was [voted](https://vote.infinex.io/#/proposal/0x295449db819f1b9412f94891f117818866c5a05d412f5a2369524d2fd9507ebf) in following the approval of [IR-2](https://proposals.infinex.xyz/irs/ir-2-governance-v1.1), be rolled over for the next epoch.
 
 Currently, the ratified voting mechanism for the Treasury Seat has not been deployed, making it impossible to elect a new Treasury Seat.
 

--- a/content/rcs/rc-14.mdoc
+++ b/content/rcs/rc-14.mdoc
@@ -15,7 +15,7 @@ Changes include:
 
 - Adding bridged variants of PYTH to all Infinex supported networks, based on official PYTH [docs](https://docs.pyth.network/home/pyth-token/pyth-token-addresses).
 - Added implementation of referral boosts as per [XIP-53](https://proposals.infinex.xyz/xips/xip-53).
-- Added badges for the Pyth airdrop in preparation for [TRF-4 ](https://proposals.infinex.xyz/trfs/trf-4)
+- Added badges for the Pyth airdrop in preparation for [TRF-4](https://proposals.infinex.xyz/trfs/trf-4)
 - Added public /public/ctp/prizes endpoint
 
 # Outcome

--- a/content/rcs/rc-2.mdoc
+++ b/content/rcs/rc-2.mdoc
@@ -54,8 +54,8 @@ The release should be deployed on a mix of Vercel, Cloudflare, PlanetScale, and 
 
 **Infinex Marketing**
 
-- Updates to the Infinex public website ([infinex.io](http://infinex.io/)), including various copy and asset changes
-- Commencement of the “Infinex 13” marketing campaign (as per the foundations set by [XIP-5](https://proposals.infinex.io/xips/xip-5-skinny-alpha-launch)), which will continue until all thirteen members of the Infinex Alpha are finalized, and includes:
+- Updates to the Infinex public website ([infinex.xyz](http://infinex.xyz/)), including various copy and asset changes
+- Commencement of the “Infinex 13” marketing campaign (as per the foundations set by [XIP-5](https://proposals.infinex.xyz/xips/xip-5-skinny-alpha-launch)), which will continue until all thirteen members of the Infinex Alpha are finalized, and includes:
   - Marketing posts on the Infinex (@infinex_app) Twitter including launch announcements, trader profiles, #infinex13, and feature showcases of the Infinex app.
   - Publication of a Mirror article outlining the core thinking and innovations of the Infinex Account.
   - Commencement of a $SNX and $ETH guessing competition in the Infinex Discord, ending December 25th (1PM UTC), that is determined by the closest guess by percentage difference. This figure will be averaged across both SNX and ETH.

--- a/content/wgcs/wgc-2.mdoc
+++ b/content/wgcs/wgc-2.mdoc
@@ -28,7 +28,7 @@ The Core Working Group (Core WG) aims to serve as the initial primary Working Gr
 
 For example, a XIP might outline the structure for an improvement to the protocol at the smart contract level, which in turn will require frontend design, frontend engineering, and a go to market strategy.
 
-This discretion is limited within the bounds outlined below, must be declared in a release candidate and approved by the Infinex Council, and must adhere to the guidelines defined in [RC-1](https://proposals.infinex.io/rcs/rc-1).
+This discretion is limited within the bounds outlined below, must be declared in a release candidate and approved by the Infinex Council, and must adhere to the guidelines defined in [RC-1](https://proposals.infinex.xyz/rcs/rc-1).
 
 - **Smart contract engineering**
   - Any XIPs that are approved by the council that require smart contract engineering (where the authors do not have the skills or resources to implement) should be implemented by the Core Working Group.

--- a/content/wgcs/wgc-3.mdoc
+++ b/content/wgcs/wgc-3.mdoc
@@ -30,7 +30,7 @@ The responsibilities of the Infra WG are:
   - All databases, servers, and/or serverless functions will be hosted by the Infra WG.
   - It falls under the mandate of the Infra WG to ensure that output of a release candidate from the Core Working Group is deployed as specified.
 - Operation of relayer network
-  - As per [XIP-3](https://proposals.infinex.io/xips/xip-3-perps), the initial implementation of the Infinex contracts will require an off-chain relayer to relay transactions. The Infra WG will ensure that this is running and topped up with gas provided by the Infinex Council.
+  - As per [XIP-3](https://proposals.infinex.xyz/xips/xip-3-perps), the initial implementation of the Infinex contracts will require an off-chain relayer to relay transactions. The Infra WG will ensure that this is running and topped up with gas provided by the Infinex Council.
 - Operation of keepers
   - Any public keepers required to operate the protocol can be run by the Infra WG as a backstop for the Infinex App, in case they aren't operated organically by the community at any point.
 - Frontend hosting
@@ -40,7 +40,7 @@ The responsibilities of the Infra WG are:
 - Infrastructure maintenance
   - Bug fixes, optimizations and improvements to any piece of the infrastructure stack specified in a Core Working Group release candidate.
 
-Any releases or changes to the above must be submitted to the Infinex Council via a Release Candidate, following the guidelines defined in [RC-1](https://proposals.infinex.io/rcs/rc-1).
+Any releases or changes to the above must be submitted to the Infinex Council via a Release Candidate, following the guidelines defined in [RC-1](https://proposals.infinex.xyz/rcs/rc-1).
 
 # Budget
 

--- a/content/wgcs/wgc-5.mdoc
+++ b/content/wgcs/wgc-5.mdoc
@@ -22,7 +22,7 @@ Github – [Gateway FM](https://github.com/gateway-fm)
 
 ### **Outcomes**
 
-Members of the proposed Data Analytics Working Group (DA WG) have been operating as part of Core Working Group and developed the Synthetix PerpsV3 API for consumption by the Infinex app Synthetix PerpsV3 integration, as detailed in [XIP-9](https://proposals.infinex.io/xips/xip-9).
+Members of the proposed Data Analytics Working Group (DA WG) have been operating as part of Core Working Group and developed the Synthetix PerpsV3 API for consumption by the Infinex app Synthetix PerpsV3 integration, as detailed in [XIP-9](https://proposals.infinex.xyz/xips/xip-9).
 
 This charter will separate these core working group members into their own working group, the DA WG, in an effort to further the decentralise the protocol.
 

--- a/content/xips/xip-10.mdoc
+++ b/content/xips/xip-10.mdoc
@@ -25,11 +25,11 @@ The Infinex Protocol smart contracts will use the variables specified in the `In
 
 There is also a special note on fee caps.
 
-Keep in mind these parameters can be changed with future governance proposals. Certain high-risk parameters will require the user to opt-in for updates as per[ XIP-7](https://proposals.infinex.io/xips/xip-7).
+Keep in mind these parameters can be changed with future governance proposals. Certain high-risk parameters will require the user to opt-in for updates as per [XIP-7](https://proposals.infinex.xyz/xips/xip-7).
 
 ## Rationale
 
-As detailed in the previous XIPs ([6](https://proposals.infinex.io/xips/xip-6), [7](https://proposals.infinex.io/xips/xip-7) & [8](https://proposals.infinex.io/xips/xip-8)) there will be various parameters and settings required for the protocol to function. This includes the latest implementations of smart contract logic, locations and allow list of tokens, fees and more.
+As detailed in the previous XIPs ([6](https://proposals.infinex.xyz/xips/xip-6), [7](https://proposals.infinex.xyz/xips/xip-7) & [8](https://proposals.infinex.xyz/xips/xip-8)) there will be various parameters and settings required for the protocol to function. This includes the latest implementations of smart contract logic, locations and allow list of tokens, fees and more.
 
 This XIP proposes the following values that will be required for the protocol to operate (e.g. contract addresses) and a good baseline for operational parameters (e.g. fees), which can be adjusted later if required.
 
@@ -141,7 +141,7 @@ The following tables outline the variables that will be used for the Ethereum Ma
 - Initial proxy implementation
 
   (`_initialProxyImplementation`)
-- The address of the contract the proxy implementation points to initially. See[ XIP-8](https://proposals.infinex.io/xips/xip-8) for more details.
+- The address of the contract the proxy implementation points to initially. See [XIP-8](https://proposals.infinex.xyz/xips/xip-8) for more details.
 - To be determined at deployment. Set to the address of the Initial Proxy Implementation contract.
 ---
 - Revenue pool

--- a/content/xips/xip-11.mdoc
+++ b/content/xips/xip-11.mdoc
@@ -23,7 +23,7 @@ Based on the above factors, as well as community feedback, the criteria for sele
 
 ## Rationale
 
-[XIP-5](https://proposals.infinex.io/xips/xip-5-skinny-alpha-launch) stated that the top 5 traders from Infinex would receive access to the Alpha Launch. However, this no longer correctly incentivises users effectively due to the technical constraints of trading on testnet.
+[XIP-5](https://proposals.infinex.xyz/xips/xip-5-skinny-alpha-launch) stated that the top 5 traders from Infinex would receive access to the Alpha Launch. However, this no longer correctly incentivises users effectively due to the technical constraints of trading on testnet.
 
 ## Technical Specification
 

--- a/content/xips/xip-14.mdoc
+++ b/content/xips/xip-14.mdoc
@@ -10,7 +10,7 @@ updated: '2024-02-05'
 ---
 # Proposal Summary
 
-This proposal aims to create a comprehensive process for managing Infinex Infrastructure and Services (IIS). It augments [WGC-3](https://proposals.infinex.io/wgcs/wgc-3) and creates a framework with which to categorise each IIS.
+This proposal aims to create a comprehensive process for managing Infinex Infrastructure and Services (IIS). It augments [WGC-3](https://proposals.infinex.xyz/wgcs/wgc-3) and creates a framework with which to categorise each IIS.
 
 # Specification
 
@@ -56,7 +56,7 @@ Control of all Strategically Valuable IIS will be maintained via a password vaul
 
 The Council will delegate the Operations Seat to manage and oversee the password vault account (the IIS Manager), disaster recovery mechanisms will be designed to enable recovery of the account should the IIS Manager be incapacitated. The IIS Manager will have authority from the Council to assign and revoke seats to each IIS managed at their discretion with input from the rest of the Council.
 
-Deployment and management of IIS that have been designated Production Environments will be restricted to the Council and the Infrastructure Working Group. Production deployment pipelines will be managed via the [RC](https://proposals.infinex.io/rcs/rc-1) process. Core WG will have full access to the development environments.
+Deployment and management of IIS that have been designated Production Environments will be restricted to the Council and the Infrastructure Working Group. Production deployment pipelines will be managed via the [RC](https://proposals.infinex.xyz/rcs/rc-1) process. Core WG will have full access to the development environments.
 
 ## Test Cases
 

--- a/content/xips/xip-15.mdoc
+++ b/content/xips/xip-15.mdoc
@@ -16,7 +16,7 @@ This XIP proposes to allocate Governance Points to actively engaged Infinex comm
 
 ## Overview
 
-Infinex aims to reward engaged community members with GP via the establishment of a Governance Points Engagement Campaign, following the [migration of Governance Points (GP) onchain](https://proposals.infinex.io/xips/xip-13). Infinex aims to distribute 50 million GP to community members who contribute in 6 different categories.
+Infinex aims to reward engaged community members with GP via the establishment of a Governance Points Engagement Campaign, following the [migration of Governance Points (GP) onchain](https://proposals.infinex.xyz/xips/xip-13). Infinex aims to distribute 50 million GP to community members who contribute in 6 different categories.
 
 These categories are:
 

--- a/content/xips/xip-16.mdoc
+++ b/content/xips/xip-16.mdoc
@@ -19,7 +19,7 @@ This proposal introduces a gas fee rebate for Infinex to pay the gas fees for al
 
 This XIP proposes to add a gas fee rebate to the Infinex accounts.
 
-A gas fee rebate is a variable configurable by the council to determine a percent of gas fees each Infinex user has to pay. To provide a smooth UX, transactions can have their gas fees paid for by Infinex, using the relay mechanism specified in [XIP-7](https://proposals.infinex.io/xips/xip-7). 
+A gas fee rebate is a variable configurable by the council to determine a percent of gas fees each Infinex user has to pay. To provide a smooth UX, transactions can have their gas fees paid for by Infinex, using the relay mechanism specified in [XIP-7](https://proposals.infinex.xyz/xips/xip-7). 
 
 For every trade and modify collateral, we take `gasFeeRebate`% of the gas fees a user pays out of their sUSD margin, since the gas fees are being paid by the relayer.
 

--- a/content/xips/xip-17.mdoc
+++ b/content/xips/xip-17.mdoc
@@ -23,7 +23,7 @@ While it would have been possible to rely only on CCTP for USDC bridging, many m
 
 ## Technical Specification
 
-Building on from [XIP-6, ](https://proposals.infinex.io/xips/xip-6)the flow is expanded with the following:
+Building on from [XIP-6](https://proposals.infinex.xyz/xips/xip-6), the flow is expanded with the following:
 
 Instead of calling the Circle CCTP contracts, the deposit account now calls the Wormhole Circle integration. This takes an additional payload in which we specify the recipient of the token. The Wormhole contract transfers the tokens to itself, verifies the payload and parameters emits a message, and calls the Circle CCTP contract, which in turn burns the tokens, and emits a message.
 

--- a/content/xips/xip-18.mdoc
+++ b/content/xips/xip-18.mdoc
@@ -33,13 +33,13 @@ Infinex is currently oversubscribed and requires a method to allocate available 
 
 #### Deposits
 
-Infinex will be accepting deposits for STW via the architecture specified in[ XIP-17](https://proposals.infinex.io/xips/xip-17). Deposits will be accepted on Ethereum, Polygon POS, Arbitrum, Optimism and Base.
+Infinex will be accepting deposits for STW via the architecture specified in [XIP-17](https://proposals.infinex.xyz/xips/xip-17). Deposits will be accepted on Ethereum, Polygon POS, Arbitrum, Optimism and Base.
 
 #### Withdrawals
 
 Withdrawals will be initially disabled via a smart contract feature flag, and will remain disabled throughout the STW campaign.
 
-Withdrawals can be enabled at any time by The Council through executing a transaction to set the feature flag using the the deployer safe. Withdrawals will operate as specified in [XIP-6](https://proposals.infinex.io/xips/xip-6).
+Withdrawals can be enabled at any time by The Council through executing a transaction to set the feature flag using the the deployer safe. Withdrawals will operate as specified in [XIP-6](https://proposals.infinex.xyz/xips/xip-6).
 
 #### Governance Points Staking Rewards
 

--- a/content/xips/xip-20.mdoc
+++ b/content/xips/xip-20.mdoc
@@ -54,7 +54,7 @@ To submit a memecoin:
 
 The Meme Olympics will kick off with an opening ceremony on a date to be announced following council approval of XIP-20. The competition will officially run for 10 days. At the conclusion of the Meme Olympics, ceremonial discord badges and Governance Points (GP) will be awarded as follows:
 
-A total of 1,000,000 GP will be distributed form the discord competition allocation specified in [XIP-15](https://proposals.infinex.io/xips/xip-15) as follows:
+A total of 1,000,000 GP will be distributed form the discord competition allocation specified in [XIP-15](https://proposals.infinex.xyz/xips/xip-15) as follows:
 
 #### **Speculator awards**
 

--- a/content/xips/xip-21.mdoc
+++ b/content/xips/xip-21.mdoc
@@ -74,7 +74,7 @@ In 2023, the Infinex Core Working Group distributed product research surveys via
 
 #### Cap the GP supply at 600,000,000 GP
 
-Following the final airdrop of 100,000,000 GP, the supply of GP will be capped, providing clarity around the value of GP ahead of [Speedrun the Waitlist](https://proposals.infinex.io/xips/xip-18).
+Following the final airdrop of 100,000,000 GP, the supply of GP will be capped, providing clarity around the value of GP ahead of [Speedrun the Waitlist](https://proposals.infinex.xyz/xips/xip-18).
 
 #### Allocate 3% of the Patron NFT Supply to GP
 
@@ -84,7 +84,7 @@ On the release of the Patron NFT, users will be able to burn 200,000 GP in excha
 
 #### Update GP to be transferrable
 
-As outlined in [XIP-13](https://proposals.infinex.io/xips/xip-13), the current technical implementation of GP does not allow it to be transferrable. If no changes were to be made to the existing functionality of GP, users who have less than 200,000 GP would be unable to do anything with their GP.
+As outlined in [XIP-13](https://proposals.infinex.xyz/xips/xip-13), the current technical implementation of GP does not allow it to be transferrable. If no changes were to be made to the existing functionality of GP, users who have less than 200,000 GP would be unable to do anything with their GP.
 
 Thus, Infinex proposes to update the `GovernancePoints.sol` to be transferrable. Infinex will still deploy `GovernancePoints.sol` as a mapping of balances (not an ERC20 token), that are not transferrable between users. However, following the end of STW, Infinex will upgrade the contract to an ERC20 token that's transferrable, in preparation for the launch of the Patron NFT.
 

--- a/content/xips/xip-22.mdoc
+++ b/content/xips/xip-22.mdoc
@@ -10,7 +10,7 @@ updated: '2023-05-14'
 ---
 # Proposal Summary
 
-XIP-22 is an update to [XIP-18: Speedrun the Waitlist](https://proposals.infinex.io/xips/xip-18).
+XIP-22 is an update to [XIP-18: Speedrun the Waitlist](https://proposals.infinex.xyz/xips/xip-18).
 
 # Specification
 
@@ -35,7 +35,7 @@ Infinex proposes some changes to the implementation of withdrawals and the Gover
 A new account implementation will be deployed to include withdrawal functionality, and will be set as the latest account implementation version by the council.
 Users will have to update to this version of the Infinex Smart Contract Account to be able to withdraw funds.
 
-Should the user opt out of upgrading their account, they will still be able to recover their funds to their specified Funds Recovery Address. Withdrawals will largely operate as specified in [XIP-6](https://proposals.infinex.io/xips/xip-6), with the exception that only sudo keys (the key directly linked to the user's passkey) will be able to enact withdrawals. This change was made to improve the security of user funds.
+Should the user opt out of upgrading their account, they will still be able to recover their funds to their specified Funds Recovery Address. Withdrawals will largely operate as specified in [XIP-6](https://proposals.infinex.xyz/xips/xip-6), with the exception that only sudo keys (the key directly linked to the user's passkey) will be able to enact withdrawals. This change was made to improve the security of user funds.
 
 Additional security may be added, including requiring a second factor that may include a signature by an EOA that the user controls.
 

--- a/content/xips/xip-23.mdoc
+++ b/content/xips/xip-23.mdoc
@@ -10,7 +10,7 @@ updated: '2023-05-14'
 ---
 # Proposal Summary
 
-XIP-23 is an update to [XIP-2: Security Core](https://proposals.infinex.io/xips/xip-2).
+XIP-23 is an update to [XIP-2: Security Core](https://proposals.infinex.xyz/xips/xip-2).
 
 # Specification
 

--- a/content/xips/xip-24.mdoc
+++ b/content/xips/xip-24.mdoc
@@ -9,7 +9,7 @@ created: '2024-05-11'
 ---
 # Proposal Summary
 
-XIP-24 proposes a minor revision to [XIP-21](https://proposals.infinex.io/xips/xip-21) by changing the airdrop to Solana users from Mad Lads holders to Saga owners.
+XIP-24 proposes a minor revision to [XIP-21](https://proposals.infinex.xyz/xips/xip-21) by changing the airdrop to Solana users from Mad Lads holders to Saga owners.
 
 # Specification
 

--- a/content/xips/xip-33.mdoc
+++ b/content/xips/xip-33.mdoc
@@ -10,7 +10,7 @@ updated: '2024-08-27'
 ---
 # Proposal Summary
 
-XIP-33 proposes the replacement of[ XIP-12 ](https://proposals.infinex.io/xips/xip-12)and the structure of the Patron NFT.
+XIP-33 proposes the replacement of [XIP-12](https://proposals.infinex.xyz/xips/xip-12) and the structure of the Patron NFT.
 
 # Specification
 

--- a/content/xips/xip-4.mdoc
+++ b/content/xips/xip-4.mdoc
@@ -10,7 +10,7 @@ updated: '2023-12-11'
 ---
 # Proposal Summary
 
-This XIP proposes a variety of changes to the current XIP framework, as well as an upgrade of the existing [XIP website](https://xips.infinex.io/all-xip/).
+This XIP proposes a variety of changes to the current XIP framework, as well as an upgrade of the existing [XIP website](https://proposals.infinex.xyz/all-xip/).
 
 # Specification
 
@@ -44,7 +44,7 @@ The process for establishing the concept of an Infinex Referendum demonstrated t
 
 The existing XIP template is inefficient and often requires repetition, it is imperative the XIP editor has the discretion to refine the XIP template to allow a smoother XIP workflow.
 
-If this XIP is passed, the XIP editor (@kmaox), will become the Infinex Proposals editor and will be given the authority to edit the [existing XIP framework](https://xips.infinex.io/xips/xip-1/) and that of any future Infinex Proposal Templates. It is also the editor's responsibility to coordinate template changes with authors and ensure they follow the current structure and workflow.
+If this XIP is passed, the XIP editor (@kmaox), will become the Infinex Proposals editor and will be given the authority to edit the [existing XIP framework](https://proposals.infinex.xyz/xips/xip-1/) and that of any future Infinex Proposal Templates. It is also the editor's responsibility to coordinate template changes with authors and ensure they follow the current structure and workflow.
 
 #### Updating the XIPs Website
 

--- a/content/xips/xip-5.mdoc
+++ b/content/xips/xip-5.mdoc
@@ -38,11 +38,11 @@ To move forward with the Infinex Alpha, where users will be able to trade on Mai
 **Alpha product scope**
 The Infinex alpha release will be an implementation on Base mainnet of the systems and architecture proposed in:
 
-- [XIP-2 – Security core](https://proposals.infinex.io/xips/xip-2)
-- [XIP-3 – Perps](https://proposals.infinex.io/xips/xip-8)
-- [XIP-6 – Crosschain architecture](https://proposals.infinex.io/xips/xip-6)
-- [XIP-7 – Infinex accounts](https://proposals.infinex.io/xips/xip-7)
-- [XIP-8 – Proxy architecture](https://proposals.infinex.io/xips/xip-8)
+- [XIP-2 – Security core](https://proposals.infinex.xyz/xips/xip-2)
+- [XIP-3 – Perps](https://proposals.infinex.xyz/xips/xip-8)
+- [XIP-6 – Crosschain architecture](https://proposals.infinex.xyz/xips/xip-6)
+- [XIP-7 – Infinex accounts](https://proposals.infinex.xyz/xips/xip-7)
+- [XIP-8 – Proxy architecture](https://proposals.infinex.xyz/xips/xip-8)
 
 **Thirteen alpha users selection**
 

--- a/content/xips/xip-6.mdoc
+++ b/content/xips/xip-6.mdoc
@@ -36,7 +36,7 @@ Infinex will then provide the UX benefit of cross-chain deposits. For now, Ether
 
 An alternative architecture using USDC pools and wormhole cross-chain queries was considered for managing the bridging of USDC, which may be proposed for future releases when tokens other than USDC need to be supported.
 
-This XIP proposes the use of the[ Circle CCTP bridge](https://www.circle.com/en/cross-chain-transfer-protocol) for the following reasons:
+This XIP proposes the use of the [Circle CCTP bridge](https://www.circle.com/en/cross-chain-transfer-protocol) for the following reasons:
 
 - It follows a trustless architecture with 3rd party (Circle) attestation across chain.
 - Supports a non-custodial Infinex architecture.
@@ -58,7 +58,7 @@ This means a `create2` salt must be stored off-chain by the contract creator (i.
 
 If a created account has a USDC balance on Ethereum, the keeper service will call a function on the Ethereum contract that will cause the contract to call the Circle CCTP bridge. This burns the tokens in exchange for a message that can be redeemed on the target chain: Base.
 
-Redemption of the message can be facilitated by anyone, and is secure as it will automatically mint USDC into the target address in the message. This can not be altered. Infinex will run a service that will, on receipt of the CCTP message, call the Circle attestation service. The Circle attestation is required for processing a message and protects against fraudulent message processing and replay protection. The Infinex service will process the message and attestation on Base, resulting in the funds being deposited into the user's Trading account. For more details on the Trading Account, please refer to [XIP-7: Infinex Accounts.](https://proposals.infinex.io/xips/xip-7)
+Redemption of the message can be facilitated by anyone, and is secure as it will automatically mint USDC into the target address in the message. This can not be altered. Infinex will run a service that will, on receipt of the CCTP message, call the Circle attestation service. The Circle attestation is required for processing a message and protects against fraudulent message processing and replay protection. The Infinex service will process the message and attestation on Base, resulting in the funds being deposited into the user's Trading account. For more details on the Trading Account, please refer to [XIP-7: Infinex Accounts](https://proposals.infinex.xyz/xips/xip-7).
 
 This diagram details the cross-chain flow for a deposit:
 
@@ -68,7 +68,7 @@ This diagram details the cross-chain flow for a deposit:
 
 A user initiates a withdrawal to a specified Ethereum address. On Base, this results in a call from their Base Trading Account to the CCTP bridge. Just like the deposit flow, the CCTP bridge burns the tokens in exchange for a message that can be attested by Circle and processed on Ethereum, resulting in the minting of USDC, this time into an address specified by the user.
 
-The amount that gets withdrawn will be the specified amount minus withdrawal fees. For more details on withdrawal fees, please see [XIP-7: Infinex Accounts.](https://proposals.infinex.io/xips/xip-7)
+The amount that gets withdrawn will be the specified amount minus withdrawal fees. For more details on withdrawal fees, please see [XIP-7: Infinex Accounts](https://proposals.infinex.xyz/xips/xip-7).
 
 This diagram details the cross-chain flow for a withdrawal:
 

--- a/content/xips/xip-70.mdoc
+++ b/content/xips/xip-70.mdoc
@@ -38,4 +38,4 @@ The Infinex account currently does not block deposits from all Solana coins, whi
 
 # Copyright
 
-Copyright and related rights waived via[ CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/content/xips/xip-75.mdoc
+++ b/content/xips/xip-75.mdoc
@@ -31,7 +31,7 @@ Any Patron Tickets a user holders over the first ten will be unaffected and used
 
 ### **Patron Community Mint Structure**
 
-As stated in[ XIP-33](https://proposals.infinex.xyz/xips/xip-33), Infinex is aiming to do a community mint, in which 50,000 Patron NFTs will be sold. Instead of a set number of Patrons being sold, this XIP proposes that up to 58,328 Patrons may be sold (at the discretion of the Treasury Seat), across four distinct waves. Each wave will allow a specific part of the community to purchase Patron NFTs. The exact times for waves are to be approved later via Release Candidate. Waves can overlap (*e.g.*, Wave 1 and Wave 2 can coincide).
+As stated in [XIP-33](https://proposals.infinex.xyz/xips/xip-33), Infinex is aiming to do a community mint, in which 50,000 Patron NFTs will be sold. Instead of a set number of Patrons being sold, this XIP proposes that up to 58,328 Patrons may be sold (at the discretion of the Treasury Seat), across four distinct waves. Each wave will allow a specific part of the community to purchase Patron NFTs. The exact times for waves are to be approved later via Release Candidate. Waves can overlap (*e.g.*, Wave 1 and Wave 2 can coincide).
 
 The supported assets for the sale are:
 
@@ -122,4 +122,4 @@ The Solana solution always forwards funds to configured external wallet addresse
 
 # Copyright
 
-Copyright and related rights waived via[ CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
Specifically, this:

* Updates some link hrefs to replace reference to obsolete addresses (`xips.infinex.io`, `proposals.infinex.io`) with the correct/current address (`proposals.infinex.xyz`)
* Moving some whitespace and punctuation to outside the anchor text

Neither of these are _content_ changes per se – I haven't modified any text displayed to the reader – only the link URLs (which were broken anyway).

In places where an obsolete address appears in the text itself, the address hasn't been updated. Eg, from XIP-4:

> Furthermore, the url will be changed from xips.infinex.io to proposals.infinex.io to accomodate for future documentation types.