### PR TITLE
Fix Typos in XIP-24 and XIP-28 Documentation

### DIFF
--- a/content/xips/xip-24.mdoc
+++ b/content/xips/xip-24.mdoc
@@ -15,7 +15,7 @@ XIP-24 proposes a minor revision to [XIP-21](https://proposals.infinex.xyz/xips/
 
 ## Overview
 
-Following recent discussions on XIP-21, a reconsideration of which crypto communities should recieve an airdrop is warranted. The changes proposed are:&nbsp;
+Following recent discussions on XIP-21, a reconsideration of which crypto communities should receive an airdrop is warranted. The changes proposed are:&nbsp;
 
 1. Remove the [Mad Lads](https://magiceden.io/marketplace/mad_lads) airdrop allocation from XIP-21.&nbsp;
 1. Grant the GP allocation to [Saga](https://solscan.io/collection/4a2d96b22ab0c8f01cb5ce5bc960b627c2a8271529ae5132d5352b7c86b3b54d) Owners.

--- a/content/xips/xip-28.mdoc
+++ b/content/xips/xip-28.mdoc
@@ -36,7 +36,7 @@ Below is the current distribution method as it stands per recents XIPs.
 [XIP-26](https://proposals.infinex.xyz/xips/xip-26) mentions:
 > This XIP proposes that the criteria of signing up for an Infinex Account and depositing at least 50 USDC, extend to the Keng Lernitas and Infinex Early Supporters airdrop recipients 
 
-However, [XIP-21](https://proposals.infinex.xyz/xips/xip-21) previously mentionned:
+However, [XIP-21](https://proposals.infinex.xyz/xips/xip-21) previously mentioned:
 > 20,488,800 GP will be allocated to the Keng Lernitas developers to distribute to Keng Lernitas holders.
 
 We want to clarify the final distribution method as the following: 


### PR DESCRIPTION


Description:  
This pull request corrects minor spelling errors in the documentation for XIP-24 and XIP-28. Specifically, it fixes the words "recieve" to "receive" and "mentionned" to "mentioned" to improve clarity and maintain consistency in the documentation. No functional or content changes have been made.
