### PR TITLE
fix: guard against missing RC id

### DIFF
--- a/src/app/rcs/page.tsx
+++ b/src/app/rcs/page.tsx
@@ -36,7 +36,7 @@ export default async function Page() {
                   key={e.slug}
                   data={e}
                   path="/rcs/"
-                  id={`RC-${number(e.entry.id || 0)}`}
+                  id={e.entry.id ? `RC-${number(e.entry.id)}` : undefined}
                 />
               ))}
             </div>

--- a/src/app/rcs/page.tsx
+++ b/src/app/rcs/page.tsx
@@ -36,7 +36,7 @@ export default async function Page() {
                   key={e.slug}
                   data={e}
                   path="/rcs/"
-                  id={`RC-${number(e.entry.id!)}`}
+                  id={`RC-${number(e.entry.id || 0)}`}
                 />
               ))}
             </div>


### PR DESCRIPTION
Avoids unsafe non-null assertion when rendering RC id. Prevents potential runtime issues if entry.id is missing